### PR TITLE
Output filepath when failing to load tsconfig.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function parseOptions(tsconfigPath) {
 
     return parsedConfig.options;
   } catch(e) {
-    throw new Error("Cannot load tsconfig.json from " + path + ": " + e.message);
+    throw new Error("Cannot load tsconfig.json from " + tsconfigPath + ": " + e.message);
   }
 }
 


### PR DESCRIPTION
Previously it was outputting:
Cannot load tsconfig.json from [object Object]: ENOENT, no such file or directory '/Users/philipbjorge/Projects/ember-ts-testbed/tsconfig.json'
