### PR TITLE
Add a configuration option for naming AMD modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ function TypeScript(inputTree, _options) {
     annotation: options.annotation
   });
 
+  this.moduleName = options.moduleName;
   this.options = loadTSConfig(options.tsconfig);
 }
 
@@ -55,5 +56,11 @@ TypeScript.prototype.cacheKeyProcessString = function(string, relativePath) {
 };
 
 TypeScript.prototype.processString = function (string, relativePath) {
-  return ts.transpileModule(string, {compilerOptions: this.options, fileName: relativePath}).outputText;
+  var options = {compilerOptions: this.options, fileName: relativePath};
+
+  if (this.moduleName) {
+    options.moduleName = this.moduleName(relativePath);
+  }
+
+  return ts.transpileModule(string, options).outputText;
 };

--- a/tests/fixtures/amd/types.js
+++ b/tests/fixtures/amd/types.js
@@ -1,0 +1,15 @@
+define("types", ["require", "exports"], function (require, exports) {
+    "use strict";
+    var Greeter = (function () {
+        function Greeter() {
+        }
+        Greeter.prototype.greet = function (thing) {
+            return "<h1>Hello, " + thing.name() + "</h1>";
+        };
+        return Greeter;
+    }());
+    exports.__esModule = true;
+    exports["default"] = Greeter;
+    ;
+    ;
+});

--- a/tests/fixtures/amd/types.ts
+++ b/tests/fixtures/amd/types.ts
@@ -1,0 +1,9 @@
+export default class Greeter {
+  greet(thing: Named) {
+    return "<h1>Hello, " + thing.name() + "</h1>";
+  }
+};
+
+export interface Named {
+  name(): String;
+};

--- a/tests/plugin-test.js
+++ b/tests/plugin-test.js
@@ -169,4 +169,29 @@ describe('transpile TypeScript', function() {
       });
     });
   });
+
+  describe('moduleName', function() {
+    it('takes a function to name AMD modules', function() {
+      builder = new broccoli.Builder(new TypeScript('tests/fixtures/amd', {
+        tsconfig: {
+          'compilerOptions': {
+            'module': 'amd'
+          }
+        },
+        moduleName: function(path) {
+          return path.replace(/\.ts$/, '');
+        }
+      }));
+
+      return builder.build().then(function(results) {
+        var outputPath = results.directory;
+        var entries = walkSync.entries(outputPath);
+
+        expect(entries).to.have.length(2);
+
+        var output = fs.readFileSync(outputPath + '/types.js', 'UTF8');
+        expect(output).match(/^define\("types", /);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Right now, to get named AMD modules I have to add a `/// <amd-module name='...' />` directive to the top of every file.

Typescript's `transpileModule` function can take a `moduleName` option to generate named modules instead of anonymous modules. This PR exposes a `moduleName` option on the Broccoli filter, which is a function that the user can provide to generate a module name from a filename.
