### PR TITLE
Return undefined from SourceCache.getScriptSnapshot for missing files

### DIFF
--- a/src/source-cache.ts
+++ b/src/source-cache.ts
@@ -59,7 +59,8 @@ export default class SourceCache {
   }
 
   public getScriptSnapshot(fileName: string): IScriptSnapshot | undefined {
-    return ScriptSnapshot.fromString(this.readFile(fileName));
+    let text = this.readFile(fileName);
+    return text !== undefined ? ScriptSnapshot.fromString(text) : undefined;
   }
 
   public readFile(fileName: string): string {

--- a/tests/fixtures/files-with-missing-imports/missing-import.ts
+++ b/tests/fixtures/files-with-missing-imports/missing-import.ts
@@ -1,0 +1,3 @@
+import foo from 'non-existent-file';
+
+foo.bar();

--- a/tests/fixtures/files-with-missing-imports/types.js
+++ b/tests/fixtures/files-with-missing-imports/types.js
@@ -1,0 +1,7 @@
+export default class Greeter {
+    greet(thing) {
+        return "<h1>Hello, " + thing.name() + "</h1>";
+    }
+}
+;
+;

--- a/tests/plugin-test.js
+++ b/tests/plugin-test.js
@@ -210,3 +210,34 @@ describe('transpile TypeScript', function() {
     });
   });
 });
+
+describe('handles missing files', function() {
+  this.timeout(10000);
+  var builder;
+
+  // TODO: random tmpdir
+  var INPUT_PATH = path.resolve(__dirname, '../tmp/input');
+
+  beforeEach(function() {
+    fs.mkdirpSync(INPUT_PATH);
+    fixturify.writeSync(INPUT_PATH, fixturify.readSync(__dirname + '/fixtures/files-with-missing-imports'));
+  });
+
+  afterEach(function () {
+    fs.removeSync(INPUT_PATH);
+    return builder.cleanup();
+  });
+
+  it('should successfully compile', function () {
+    builder = new broccoli.Builder(filter(INPUT_PATH, {
+      tsconfig: __dirname + '/fixtures/tsconfig.json'
+    }));
+
+    return builder.build().then(function(results) {
+      var outputPath = results.directory;
+      var entries = walkSync.entries(outputPath);
+
+      expect(entries).to.have.length(2);
+    });
+  });
+})


### PR DESCRIPTION
If the file being snapshotted does not exist, then `this.readFile(fileName)` will return undefined. `ScriptSnapshot.fromString()` doesn't handle undefined values - the compiler expects that the `getScriptSnapshot()` method would return undefined instead of a ScriptSnapshot with no text.