### PR TITLE
fix plugin using cached version on first rebuild

### DIFF
--- a/lib/plugin.ts
+++ b/lib/plugin.ts
@@ -68,9 +68,8 @@ export class TypeScript extends BroccoliPlugin {
     let host = this.host;
     if (!host) {
       host = this.host = new Compiler(this.outputPath, inputPath, this.config, this.configFileName);
-    } else {
-      host.updateInput(inputPath);
     }
+    host.updateInput(inputPath);
     host.compile();
     heimdall.stop(token);
   }

--- a/tests/plugin-test.ts
+++ b/tests/plugin-test.ts
@@ -144,6 +144,66 @@ exports.A = a_1.default;
     });
   });
 
+  it("compiles changes on first rebuild", async () => {
+    input.write({
+      "a.ts": `export default class A {}`
+    });
+
+    output = createBuilder(typescript(input.path(), {
+      tsconfig: {
+        compilerOptions: {
+          module: "commonjs",
+          moduleResolution: "node",
+          newLine: "LF",
+          target: "es2015"
+        },
+        files: ["a.ts"]
+      }
+    }));
+
+    await output.build();
+
+    expect(
+      output.changes()
+    ).to.be.deep.equal({
+      "a.js": "create"
+    });
+
+    expect(
+      output.read()
+    ).to.deep.equal({
+      "a.js": `"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+class A {
+}
+exports.default = A;
+`
+    });
+
+    input.write({
+      "a.ts": `export default class A1 {}`
+    });
+
+    await output.build();
+
+    expect(
+      output.changes()
+    ).to.be.deep.equal({
+      "a.js": "change"
+    });
+
+    expect(
+      output.read()
+    ).to.deep.equal({
+      "a.js": `"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+class A1 {
+}
+exports.default = A1;
+`
+    });
+  });
+
   it("handles missing files", async () => {
     input.write({
       "index.ts": `export { default as A } from "./a";`
@@ -174,3 +234,4 @@ exports.A = a_1.default;
     });
   });
 });
+


### PR DESCRIPTION
I finally got around to make a fix for the issue described in #33 where the input tree is not updated on first rebuild. It has caused us some pain, as the first changes after restarting `broccoli serve` were never applied, especially if multiple files were changed.

Note that calling `host.updateInput()` on the first rebuild may mask an underlying bug when constructing the `Compiler`, but it seems to work.