### PR TITLE
Path control

### DIFF
--- a/lib/compiler/create-compiler-host.ts
+++ b/lib/compiler/create-compiler-host.ts
@@ -17,15 +17,14 @@ import InputIO from "./input-io";
 import SourceCache from "./source-cache";
 
 export default function createCompilerHost(
-  rootPath: Path, input: InputIO, sourceCache: SourceCache, compilerOptions: CompilerOptions,
+  workingPath: Path, input: InputIO, sourceCache: SourceCache, compilerOptions: CompilerOptions,
 ): CompilerHost {
   const newLine = getNewLine(compilerOptions);
-  const currentDirectory = rootPath;
   return {
     directoryExists: (path) => input.directoryExists(path),
     fileExists: (path) => input.fileExists(path),
     getCanonicalFileName,
-    getCurrentDirectory: () => currentDirectory,
+    getCurrentDirectory: () => workingPath,
     getDefaultLibFileName: (options) => toPath(getDefaultLibFileName(options), defaultLibLocation),
     getDefaultLibLocation: () => defaultLibLocation,
     getDirectories: (path) => input.getDirectories(path),

--- a/lib/compiler/create-parse-config-host.ts
+++ b/lib/compiler/create-parse-config-host.ts
@@ -3,9 +3,7 @@ import { useCaseSensitiveFileNames } from "../fs/path-utils";
 import { Path } from "../interfaces";
 import InputIO from "./input-io";
 
-export default function createParseConfigHost(rootPath: Path, input: InputIO): ParseConfigHost {
-  const currentDirectory = rootPath;
-
+export default function createParseConfigHost(workingPath: Path, input: InputIO): ParseConfigHost {
   function getFileSystemEntries(path: string) {
     return input.getFileSystemEntries(path);
   }
@@ -13,7 +11,7 @@ export default function createParseConfigHost(rootPath: Path, input: InputIO): P
   function readDirectory(rootDir: string, extensions: string[], excludes: string[], includes: string[]): string[] {
     return matchFiles(
       rootDir, extensions, excludes, includes,
-      useCaseSensitiveFileNames, currentDirectory, getFileSystemEntries);
+      useCaseSensitiveFileNames, workingPath, getFileSystemEntries);
   }
 
   function fileExists(path: string): boolean {

--- a/lib/diagnostics-handler.ts
+++ b/lib/diagnostics-handler.ts
@@ -8,7 +8,7 @@ export default class DiagnosticsHandlerImpl implements DiagnosticsHandler {
 
   constructor(options: NormalizedOptions) {
     this.throwOnError = options.throwOnError;
-    this.host = createFormatDiagnosticsHost(options.rootPath);
+    this.host = createFormatDiagnosticsHost(options.workingPath);
   }
 
   public setWrite(write: (s: string) => void) {

--- a/lib/normalize-options.ts
+++ b/lib/normalize-options.ts
@@ -1,13 +1,21 @@
 import {
-  getDirectoryPath,
+  isWithin,
   normalizePath,
   toPath,
 } from "./fs/path-utils";
 import { CompilerOptionsConfig, NormalizedOptions, TypeScriptPluginOptions } from "./interfaces";
 
 export default function normalizeOptions(options: TypeScriptPluginOptions): NormalizedOptions {
-  let rootPath = options.rootPath;
+  const workingPath = toPath(options.workingPath === undefined ? process.cwd() : options.workingPath);
+  const rootPath = options.rootPath === undefined ? workingPath : toPath(options.rootPath, workingPath);
+  const projectPath = options.projectPath === undefined ? rootPath : toPath(options.projectPath, workingPath);
+  const buildPath = options.buildPath === undefined ? undefined : toPath(options.buildPath, workingPath);
   const tsconfig = options.tsconfig;
+
+  if (buildPath !== undefined &&
+      !(rootPath === buildPath || isWithin(rootPath, buildPath))) {
+    throw new Error(`buildPath "${buildPath}" must be at or within rootPath "${rootPath}"`);
+  }
 
   let configFileName: string | undefined;
   let rawConfig: CompilerOptionsConfig | undefined;
@@ -19,24 +27,19 @@ export default function normalizeOptions(options: TypeScriptPluginOptions): Norm
     rawConfig = undefined;
   }
 
-  if (rootPath === undefined) {
-    if (configFileName) {
-      rootPath = getDirectoryPath(configFileName);
-    } else {
-      rootPath = ".";
-    }
-  }
-
   let throwOnError = options.throwOnError;
   if (throwOnError === undefined) {
     throwOnError = process.env.NODE_ENV === "production";
   }
 
   return {
+    buildPath,
     compilerOptions: options.compilerOptions,
     configFileName,
+    projectPath,
     rawConfig,
-    rootPath: toPath(rootPath),
+    rootPath,
     throwOnError,
+    workingPath,
   };
 }

--- a/tests/cases-test.ts
+++ b/tests/cases-test.ts
@@ -20,7 +20,7 @@ QUnit.module("plugin-cases", function() {
         compilerOptions: {
           noEmitOnError: true,
         },
-        tsconfig: testCasesDir.path(testCase + "/tsconfig.json"),
+        rootPath: testCasesDir.path(testCase)
       }));
 
       await output.build();

--- a/tests/config-parser-test.ts
+++ b/tests/config-parser-test.ts
@@ -63,6 +63,7 @@ QUnit.module("config-parser", {
         undefined,
         "lib/tsconfig.json",
         { module: "umd" },
+        rootPath,
         new InputIO(new PathResolver(rootPath, inputPath)),
       );
       const parsed = parser.parseConfig();

--- a/tests/plugin-test.ts
+++ b/tests/plugin-test.ts
@@ -128,7 +128,7 @@ exports.A = a_1.default;
         "index.ts": `export { default as A } from "./a";`,
       });
 
-      const output = createBuilder(typescript(input.path(), {
+      const plugin = typescript(input.path(), {
         tsconfig: {
           compilerOptions: {
             module: "commonjs",
@@ -138,7 +138,12 @@ exports.A = a_1.default;
           },
           files: ["index.ts"],
         },
-      }));
+      });
+
+      let error = "";
+      plugin.setDiagnosticWriter((msg) => error += msg)
+
+      const output = createBuilder(plugin);
       try {
 
         await output.build();
@@ -150,6 +155,8 @@ var a_1 = require("./a");
 exports.A = a_1.default;
 `,
         });
+
+        assert.equal(error.trim(), "index.ts(1,30): error TS2307: Cannot find module './a'.")
 
       } finally {
         await output.dispose();

--- a/tests/typescript-project-runner.ts
+++ b/tests/typescript-project-runner.ts
@@ -71,12 +71,6 @@ export class Project {
     return path.join(this.rootDir, this.config.projectRoot);
   }
 
-  get tsconfigFile(): string | undefined {
-    if (this.config.project) {
-      return path.join(this.config.project, "tsconfig.json");
-    }
-  }
-
   get inputFiles(): string[] | undefined {
     return this.config.inputFiles;
   }
@@ -119,17 +113,19 @@ export class ProjectWithModule {
   get pluginConfig(): TypeScriptConfig {
     const { project } = this;
     const inputFiles = project.inputFiles;
-    const tsconfigFile = project.tsconfigFile;
     const config: TypeScriptConfig = {
       compilerOptions: this.compilerOptions,
-      rootPath: this.project.dir,
+      workingPath: this.project.dir,
+      buildPath: this.project.dir
     };
 
-    if (tsconfigFile) {
-      config.tsconfig = tsconfigFile;
-    } else if (inputFiles) {
+    if (inputFiles) {
       config.compilerOptions!.moduleResolution = "classic";
-      config.tsconfig = { files: inputFiles };
+      config.tsconfig = {
+        files: inputFiles
+      };
+    } else {
+      config.projectPath = project.config.project;
     }
 
     return config;


### PR DESCRIPTION
add more control over paths
allow working dir to be different from root, and
project search path to be different from root, and
build path to be set to control stripping from
output.

default to remove outDir from path if buildPath not
set.

set noEmit to false if set