### PR TITLE
upgrades typescript dep to 2.6.1. fixes types def for WalkSync.Entry:…

### DIFF
--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -47,6 +47,7 @@ export namespace WalkSync {
     relativePath: string;
     basePath: string;
     fullPath: string;
+    checksum: string;
     mode: number;
     size: number;
     mtime: Date;

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -22,7 +22,7 @@ export interface DiagnosticsHandler {
    *
    * Returns true if there are errors.
    */
-  check(diagnostics: Diagnostic[] | Diagnostic | undefined, throwOnError?: boolean): boolean;
+  check(diagnostics: ReadonlyArray<Diagnostic> | Diagnostic | undefined, throwOnError?: boolean): boolean;
 }
 
 export interface TypeScriptPluginOptions {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "fs-tree-diff": "^0.5.2",
     "heimdalljs": "0.3.3",
     "md5-hex": "^2.0.0",
-    "typescript": "~2.5.2",
+    "typescript": "~2.6.1",
     "walk-sync": "^0.3.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1847,9 +1847,9 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
 
-typescript@~2.5.2:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.2.tgz#038a95f7d9bbb420b1bf35ba31d4c5c1dd3ffe34"
+typescript@~2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.1.tgz#ef39cdea27abac0b500242d6726ab90e0c846631"
 
 uglify-js@^2.6:
   version "2.8.12"


### PR DESCRIPTION
… adds checksum prop. changes diagnostic parameter on check interface to ReadonlyArray

resolves #53 