### PR TITLE
Preserve file path casing in output

### DIFF
--- a/lib/cache/directory-entries-cache-delegate.ts
+++ b/lib/cache/directory-entries-cache-delegate.ts
@@ -1,14 +1,14 @@
 import { readdir } from "../fs/file-utils";
-import { CacheDelegate, DirEntries, Path, PathResolver } from "../interfaces";
+import { CacheDelegate, CanonicalPath, DirEntries, PathResolver } from "../interfaces";
 
-export default class DirEntriesCacheDelegate implements CacheDelegate<Path, Path, DirEntries> {
+export default class DirEntriesCacheDelegate implements CacheDelegate<CanonicalPath, CanonicalPath, DirEntries> {
   constructor(private resolver: PathResolver) {}
 
-  public cacheKey(path: Path): Path {
+  public cacheKey(path: CanonicalPath): CanonicalPath {
     return path;
   }
 
-  public create(path: Path): DirEntries {
+  public create(path: CanonicalPath): DirEntries {
     return readdir(path, this.resolver);
   }
 }

--- a/lib/cache/directory-entries-cache.ts
+++ b/lib/cache/directory-entries-cache.ts
@@ -1,8 +1,8 @@
 import Cache from "../cache";
-import { DirEntries, Path, PathResolver } from "../interfaces";
+import { CanonicalPath, DirEntries, PathResolver } from "../interfaces";
 import DirEntriesCacheDelegate from "./directory-entries-cache-delegate";
 
-export default class DirEntriesCache extends Cache<Path, Path, DirEntries> {
+export default class DirEntriesCache extends Cache<CanonicalPath, CanonicalPath, DirEntries> {
   constructor(resolver: PathResolver) {
     super(new DirEntriesCacheDelegate(resolver));
   }

--- a/lib/cache/path-info-cache-delegate.ts
+++ b/lib/cache/path-info-cache-delegate.ts
@@ -1,12 +1,13 @@
 import parsePath from "../fs/parse-path";
-import { CacheDelegate, Path, PathInfo} from "../interfaces";
+import { toCanonicalPath } from "../fs/path-utils";
+import { AbsolutePath, CacheDelegate, CanonicalPath, PathInfo} from "../interfaces";
 
-export default class PathInfoCacheDelegate implements CacheDelegate<string, string, PathInfo> {
-  constructor(private rootPath: Path, private inputPath: Path) {
+export default class PathInfoCacheDelegate implements CacheDelegate<string, CanonicalPath, PathInfo> {
+  constructor(private rootPath: AbsolutePath, private inputPath: AbsolutePath) {
   }
 
-  public cacheKey(key: string): string {
-    return key;
+  public cacheKey(key: string): CanonicalPath {
+    return toCanonicalPath(key, this.rootPath);
   }
 
   public create(key: string) {

--- a/lib/cache/path-info-cache.ts
+++ b/lib/cache/path-info-cache.ts
@@ -1,9 +1,9 @@
 import Cache from "../cache";
-import { Path, PathInfo } from "../interfaces";
+import { AbsolutePath, CanonicalPath, PathInfo } from "../interfaces";
 import PathInfoCacheDelegate from "./path-info-cache-delegate";
 
-export default class PathInfoCache extends Cache<string, string, PathInfo> {
-  constructor(rootPath: Path, inputPath: Path) {
+export default class PathInfoCache extends Cache<string, CanonicalPath, PathInfo> {
+  constructor(rootPath: AbsolutePath, inputPath: AbsolutePath) {
     super(new PathInfoCacheDelegate(rootPath, inputPath));
   }
 }

--- a/lib/cache/resolution-cache-delegate.ts
+++ b/lib/cache/resolution-cache-delegate.ts
@@ -1,9 +1,9 @@
 import resolve from "../fs/resolve";
-import { CacheDelegate, Path, PathInfo, Resolution} from "../interfaces";
+import { CacheDelegate, CanonicalPath, PathInfo, Resolution} from "../interfaces";
 
-export default class ResolutionCacheDelegate implements CacheDelegate<PathInfo, Path, Resolution> {
-  public cacheKey(pathInfo: PathInfo): Path {
-    return pathInfo.path;
+export default class ResolutionCacheDelegate implements CacheDelegate<PathInfo, CanonicalPath, Resolution> {
+  public cacheKey(pathInfo: PathInfo): CanonicalPath {
+    return pathInfo.canonicalPath;
   }
 
   public create(pathInfo: PathInfo) {

--- a/lib/cache/resolution-cache.ts
+++ b/lib/cache/resolution-cache.ts
@@ -1,8 +1,8 @@
 import Cache from "../cache";
-import { Path, PathInfo, Resolution } from "../interfaces";
+import { CanonicalPath, PathInfo, Resolution } from "../interfaces";
 import ResolutionCacheDelegate from "./resolution-cache-delegate";
 
-export default class ResolutionCache extends Cache<PathInfo, Path, Resolution> {
+export default class ResolutionCache extends Cache<PathInfo, CanonicalPath, Resolution> {
   constructor() {
     super(new ResolutionCacheDelegate());
   }

--- a/lib/compiler/config-parser.ts
+++ b/lib/compiler/config-parser.ts
@@ -1,17 +1,17 @@
 import * as ts from "typescript";
-import {getDirectoryPath } from "../fs/path-utils";
-import { CompilerOptionsConfig, Path, TypeScriptConfig } from "../interfaces";
+import { getDirectoryPath } from "../fs/path-utils";
+import { AbsolutePath, CompilerOptionsConfig, TypeScriptConfig } from "../interfaces";
 import createParseConfigHost from "./create-parse-config-host";
 import Input from "./input-io";
 
 export default class ConfigParser {
   private host: ts.ParseConfigHost;
 
-  constructor(private projectPath: Path,
+  constructor(private projectPath: AbsolutePath,
               private rawConfig: TypeScriptConfig | undefined,
               private configFileName: string | undefined,
               private compilerOptions: CompilerOptionsConfig | undefined,
-              workingPath: Path,
+              workingPath: AbsolutePath,
               input: Input) {
     this.host = createParseConfigHost(workingPath, input);
   }
@@ -34,24 +34,24 @@ export default class ConfigParser {
     return result;
   }
 
-  private resolveConfigFileName(): Path | undefined {
+  private resolveConfigFileName(): AbsolutePath | undefined {
     if (this.rawConfig !== undefined) {
       return;
     }
     return ts.findConfigFile(
       this.projectPath,
       this.host.fileExists,
-      this.configFileName) as Path;
+      this.configFileName) as AbsolutePath;
   }
 
-  private getBasePath(configFilePath: Path | undefined) {
+  private getBasePath(configFilePath: AbsolutePath | undefined): AbsolutePath {
     if (configFilePath === undefined) {
       return this.projectPath;
     }
-    return getDirectoryPath(configFilePath);
+    return getDirectoryPath(configFilePath) as AbsolutePath;
   }
 
-  private convertExistingOptions(basePath: Path) {
+  private convertExistingOptions(basePath: AbsolutePath) {
     const { compilerOptions } = this;
     if (compilerOptions === undefined) {
       return {
@@ -62,7 +62,7 @@ export default class ConfigParser {
     return ts.convertCompilerOptionsFromJson(this.compilerOptions, basePath);
   }
 
-  private readConfigSourceFile(configFilePath: Path | undefined): ts.JsonSourceFile | undefined {
+  private readConfigSourceFile(configFilePath: AbsolutePath | undefined): ts.JsonSourceFile | undefined {
     if (configFilePath === undefined) {
       return;
     }
@@ -74,8 +74,8 @@ export default class ConfigParser {
   }
 
   private parseConfigContent(
-    configFileName: Path | undefined,
-    basePath: Path,
+    configFileName: AbsolutePath | undefined,
+    basePath: AbsolutePath,
     existingOptions: ts.CompilerOptions | undefined,
   ) {
     const configSourceFile = this.readConfigSourceFile(configFileName);

--- a/lib/compiler/create-compiler-host.ts
+++ b/lib/compiler/create-compiler-host.ts
@@ -9,15 +9,15 @@ import {
 import {
   defaultLibLocation,
   getCanonicalFileName,
-  toPath,
+  toCanonicalPath,
   useCaseSensitiveFileNames,
 } from "../fs/path-utils";
-import { Path } from "../interfaces";
+import { AbsolutePath } from "../interfaces";
 import InputIO from "./input-io";
 import SourceCache from "./source-cache";
 
 export default function createCompilerHost(
-  workingPath: Path, input: InputIO, sourceCache: SourceCache, compilerOptions: CompilerOptions,
+  workingPath: AbsolutePath, input: InputIO, sourceCache: SourceCache, compilerOptions: CompilerOptions,
 ): CompilerHost {
   const newLine = getNewLine(compilerOptions);
   return {
@@ -25,7 +25,7 @@ export default function createCompilerHost(
     fileExists: (path) => input.fileExists(path),
     getCanonicalFileName,
     getCurrentDirectory: () => workingPath,
-    getDefaultLibFileName: (options) => toPath(getDefaultLibFileName(options), defaultLibLocation),
+    getDefaultLibFileName: (options) => toCanonicalPath(getDefaultLibFileName(options), defaultLibLocation),
     getDefaultLibLocation: () => defaultLibLocation,
     getDirectories: (path) => input.getDirectories(path),
     getNewLine: () => newLine,

--- a/lib/compiler/create-parse-config-host.ts
+++ b/lib/compiler/create-parse-config-host.ts
@@ -1,9 +1,9 @@
 import { matchFiles, ParseConfigHost } from "typescript";
 import { useCaseSensitiveFileNames } from "../fs/path-utils";
-import { Path } from "../interfaces";
+import { AbsolutePath } from "../interfaces";
 import InputIO from "./input-io";
 
-export default function createParseConfigHost(workingPath: Path, input: InputIO): ParseConfigHost {
+export default function createParseConfigHost(workingPath: AbsolutePath, input: InputIO): ParseConfigHost {
   function getFileSystemEntries(path: string) {
     return input.getFileSystemEntries(path);
   }

--- a/lib/compiler/input-io.ts
+++ b/lib/compiler/input-io.ts
@@ -1,7 +1,7 @@
 import { realpathSync } from "fs";
 import * as ts from "typescript";
 import DirectoryEntriesCache from "../cache/directory-entries-cache";
-import { DirEntries, Path, PathResolver, Resolution } from "../interfaces";
+import { AbsolutePath, CanonicalPath, DirEntries, PathResolver, Resolution } from "../interfaces";
 
 export default class Input {
   private entriesCache: DirectoryEntriesCache;
@@ -29,16 +29,16 @@ export default class Input {
     let directories: string[];
     if (resolution.isDirectory()) {
       if (resolution.isInput()) {
-        directories = this.readdir(resolution.pathInInput).directories;
+        directories = this.readdir(resolution.canonicalPathInInput).directories;
         if (resolution.isMerged()) {
-          for (const other in this.readdir(resolution.path).directories) {
+          for (const other in this.readdir(resolution.canonicalPath).directories) {
             if (directories.indexOf(other) === -1) {
               directories.push(other);
             }
           }
         }
       } else {
-        directories = this.readdir(resolution.path).directories;
+        directories = this.readdir(resolution.canonicalPath).directories;
       }
     } else {
       directories = [];
@@ -57,7 +57,7 @@ export default class Input {
     const resolution = this.resolve(path);
     let entries: DirEntries;
     if (resolution.isDirectory() && resolution.isInput()) {
-      entries = this.readdir(resolution.pathInInput);
+      entries = this.readdir(resolution.canonicalPathInInput);
     } else {
       entries = { files: [], directories: [] };
     }
@@ -66,7 +66,7 @@ export default class Input {
 
   public readFile(path: string): string | undefined {
     const resolution = this.resolve(path);
-    let resolved: Path | undefined;
+    let resolved: AbsolutePath | undefined;
     if (resolution.isFile()) {
       if (resolution.isInput()) {
         resolved = resolution.pathInInput;
@@ -83,7 +83,7 @@ export default class Input {
     return this.resolve(path).relativePath;
   }
 
-  public realpath(path: string): Path | undefined {
+  public realpath(path: string): AbsolutePath | undefined {
     const resolution = this.resolve(path);
     if (resolution.isInput()) {
       return resolution.path;
@@ -102,7 +102,7 @@ export default class Input {
     return this.resolver.resolve(path);
   }
 
-  private readdir(path: Path) {
+  private readdir(path: CanonicalPath) {
     return this.entriesCache.get(path);
   }
 }

--- a/lib/compiler/path-resolver.ts
+++ b/lib/compiler/path-resolver.ts
@@ -1,12 +1,12 @@
 import PathInfoCache from "../cache/path-info-cache";
 import ResolutionCache from "../cache/resolution-cache";
-import { Path, PathResolver, Resolution } from "../interfaces";
+import { AbsolutePath, PathResolver, Resolution } from "../interfaces";
 
 export default class PathResolverImpl implements PathResolver {
   private pathInfoCache: PathInfoCache;
   private resolutionCache = new ResolutionCache();
 
-  constructor(rootPath: Path, inputPath: Path) {
+  constructor(rootPath: AbsolutePath, inputPath: AbsolutePath) {
     this.pathInfoCache = new PathInfoCache(rootPath, inputPath);
   }
 

--- a/lib/compiler/source-cache.ts
+++ b/lib/compiler/source-cache.ts
@@ -1,6 +1,6 @@
 import * as ts from "typescript";
 import { readFileResolution } from "../fs/file-utils";
-import { FileContent, Path, PathResolver, Resolution } from "../interfaces";
+import { CanonicalPath, FileContent, PathResolver, Resolution } from "../interfaces";
 
 const SharedRegistry = ts.createDocumentRegistry();
 
@@ -12,7 +12,7 @@ interface VersionedSourceFile {
 export default class SourceCache {
   private bucketKey: ts.DocumentRegistryBucketKey;
 
-  private sourceFiles = new Map<Path, VersionedSourceFile>();
+  private sourceFiles = new Map<CanonicalPath, VersionedSourceFile>();
 
   constructor( private resolver: PathResolver, private options: ts.CompilerOptions) {
     this.bucketKey = SharedRegistry.getKeyForCompilationSettings(options);
@@ -29,10 +29,10 @@ export default class SourceCache {
 
   public getSourceFile(fileName: string): ts.SourceFile | undefined {
     const resolution = this.resolve(fileName);
-    return this.getSourceFileByPath(fileName, resolution.path);
+    return this.getSourceFileByPath(fileName, resolution.canonicalPath);
   }
 
-  public getSourceFileByPath(fileName: string, path: Path): ts.SourceFile | undefined {
+  public getSourceFileByPath(fileName: string, path: CanonicalPath): ts.SourceFile | undefined {
     const resolution = this.resolve(path);
     return this.getSourceFileByResolution(resolution, fileName, path);
   }
@@ -59,14 +59,18 @@ export default class SourceCache {
     return this.resolver.resolve(fileName);
   }
 
-  private getSourceFileByResolution(resolution: Resolution, fileName: string, path: Path): ts.SourceFile | undefined {
+  private getSourceFileByResolution(
+    resolution: Resolution,
+    fileName: string,
+    path: CanonicalPath,
+  ): ts.SourceFile | undefined {
     const content = readFileResolution(resolution);
     if (content) {
       return this.getOrUpdateSourceFile(fileName, path, content);
     }
   }
 
-  private getOrUpdateSourceFile(fileName: string, path: Path, content: FileContent) {
+  private getOrUpdateSourceFile(fileName: string, path: CanonicalPath, content: FileContent) {
     const existing = this.sourceFiles.get(path);
     if (existing) {
       return this.updateSourceFile(existing, fileName, path, content);
@@ -75,7 +79,7 @@ export default class SourceCache {
     }
   }
 
-  private updateSourceFile(existing: VersionedSourceFile, fileName: string, path: Path, content: FileContent) {
+  private updateSourceFile(existing: VersionedSourceFile, fileName: string, path: CanonicalPath, content: FileContent) {
     const { version } = content;
     if (existing.version === version) {
       return existing.sourceFile;
@@ -88,7 +92,7 @@ export default class SourceCache {
     return sourceFile;
   }
 
-  private createSourceFile(fileName: string, path: Path, content: FileContent) {
+  private createSourceFile(fileName: string, path: CanonicalPath, content: FileContent) {
     const { options, bucketKey, sourceFiles } = this;
     const { buffer, version } = content;
     const sourceFile = SharedRegistry.acquireDocumentWithKey(

--- a/lib/diagnostics-handler.ts
+++ b/lib/diagnostics-handler.ts
@@ -1,5 +1,6 @@
-import { Diagnostic, formatDiagnostics, FormatDiagnosticsHost, Path, sys } from "typescript";
-import { DiagnosticsHandler, NormalizedOptions } from "./interfaces";
+import { Diagnostic, formatDiagnostics, FormatDiagnosticsHost, sys } from "typescript";
+import { getCanonicalFileName } from "./fs/path-utils";
+import { AbsolutePath, DiagnosticsHandler, NormalizedOptions } from "./interfaces";
 
 export default class DiagnosticsHandlerImpl implements DiagnosticsHandler {
   private throwOnError: boolean;
@@ -43,11 +44,9 @@ function normalize(diagnostics: Diagnostic | Diagnostic[] | undefined): Diagnost
   return [ diagnostics ];
 }
 
-function createFormatDiagnosticsHost(rootPath: Path): FormatDiagnosticsHost {
+function createFormatDiagnosticsHost(rootPath: AbsolutePath): FormatDiagnosticsHost {
   const newLine = sys.newLine;
-  const getCanonicalFileName = sys.useCaseSensitiveFileNames ?
-    (f: string) => f :
-    (f: string) => f.toLowerCase();
+
   return {
     getCanonicalFileName,
     getCurrentDirectory: () => rootPath,

--- a/lib/fs/file-utils.ts
+++ b/lib/fs/file-utils.ts
@@ -1,8 +1,8 @@
 import { createHash } from "crypto";
 import { readdirSync, readFileSync, Stats, statSync } from "fs";
-import { DirEntries, FileContent, Path, PathResolver, Resolution } from "../interfaces";
+import { AbsolutePath, CanonicalPath, DirEntries, FileContent, PathResolver, Resolution } from "../interfaces";
 
-export function readFile(path: Path): FileContent {
+export function readFile(path: AbsolutePath): FileContent {
   const buffer = readFileSync(path);
   const hash = createHash("sha1");
   hash.update(buffer);
@@ -10,7 +10,7 @@ export function readFile(path: Path): FileContent {
 }
 
 export function readFileResolution(resolution: Resolution) {
-  let path: Path | undefined;
+  let path: AbsolutePath | undefined;
   if (resolution.isFile()) {
     if (resolution.isInput()) {
       path = resolution.pathInInput;
@@ -23,7 +23,7 @@ export function readFileResolution(resolution: Resolution) {
   }
 }
 
-export function stat(path: Path): Stats | undefined {
+export function stat(path: AbsolutePath): Stats | undefined {
   try {
     return statSync(path);
   } catch (e) {
@@ -34,7 +34,7 @@ export function stat(path: Path): Stats | undefined {
   }
 }
 
-export function readdir(path: Path, resolver: PathResolver): DirEntries {
+export function readdir(path: CanonicalPath, resolver: PathResolver): DirEntries {
   const prefix = path + "/";
   const files: string[] = [];
   const directories: string[] = [];

--- a/lib/fs/parse-path.ts
+++ b/lib/fs/parse-path.ts
@@ -1,20 +1,26 @@
-import { Path, PathInfo } from "../interfaces";
-import { relativePathWithin, toPath } from "./path-utils";
+import { AbsolutePath, PathInfo } from "../interfaces";
+import { relativePathWithin, toAbsolutePath, toCanonicalPath } from "./path-utils";
 
-export default function parsePath(rootPath: Path, inputPath: Path, rawPath: string): PathInfo {
-  let path = toPath(rawPath, rootPath);
-  let pathInInput: Path | undefined;
+export default function parsePath(rootPath: AbsolutePath, inputPath: AbsolutePath, rawPath: string): PathInfo {
+  let path = toAbsolutePath(rawPath, rootPath);
+  let pathInInput: AbsolutePath | undefined;
   let relativePath = relativePathWithin(rootPath, path);
   if (relativePath === undefined) {
     relativePath = relativePathWithin(inputPath, path);
     if (relativePath !== undefined) {
       pathInInput = path;
-      path = toPath(relativePath, rootPath);
+      path = toAbsolutePath(relativePath, rootPath);
     }
   } else {
-    pathInInput = toPath(relativePath, inputPath);
+    pathInInput = toAbsolutePath(relativePath, inputPath);
   }
+
+  const canonicalPath = toCanonicalPath(path);
+  const canonicalPathInInput = pathInInput && toCanonicalPath(pathInInput);
+
   return {
+    canonicalPath,
+    canonicalPathInInput,
     path,
     pathInInput,
     relativePath,

--- a/lib/fs/resolve.ts
+++ b/lib/fs/resolve.ts
@@ -1,11 +1,12 @@
 import { Stats } from "fs";
 import {
+  AbsolutePath,
+  CanonicalPath,
   DirectoryResolution,
   FileResolution,
   InputDirectoryResolution,
   InputFileResolution,
   MergedDirectoryResolution,
-  Path,
   PathInfo,
   Resolution,
 } from "../interfaces";
@@ -46,8 +47,10 @@ const enum ResolutionFlags {
 }
 
 class ResolutionImpl implements Resolution {
-  public path: Path;
-  public pathInInput: Path | undefined;
+  public canonicalPath: CanonicalPath;
+  public canonicalPathInInput: CanonicalPath | undefined;
+  public path: AbsolutePath;
+  public pathInInput: AbsolutePath | undefined;
   public relativePath: string | undefined;
 
   constructor(
@@ -56,6 +59,8 @@ class ResolutionImpl implements Resolution {
     public otherStats: Stats | undefined,
     private flags: ResolutionFlags,
   ) {
+    this.canonicalPath = pathInfo.canonicalPath;
+    this.canonicalPathInInput = pathInfo.canonicalPathInInput;
     this.path = pathInfo.path;
     this.pathInInput = pathInfo.pathInInput;
     this.relativePath = pathInfo.relativePath;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -5,4 +5,4 @@ export * from "./plugin";
 export { default as ConfigParser } from "./compiler/config-parser";
 export { default as InputIO } from "./compiler/input-io";
 export { default as PathResolver } from "./compiler/path-resolver";
-export { normalizePath, relativePathWithin, toPath } from "./fs/path-utils";
+export { normalizePath, relativePathWithin, toAbsolutePath, toCanonicalPath } from "./fs/path-utils";

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -6,10 +6,10 @@ export * from "./generated/typescript-config";
 export type CompilerOptionsConfig = TypeScriptConfig["compilerOptions"];
 
 export interface NormalizedOptions {
-  workingPath: Path;
-  rootPath: Path;
-  projectPath: Path;
-  buildPath: Path | undefined;
+  workingPath: AbsolutePath;
+  rootPath: AbsolutePath;
+  projectPath: AbsolutePath;
+  buildPath: AbsolutePath | undefined;
   configFileName: string | undefined;
   rawConfig: CompilerOptionsConfig | undefined;
   compilerOptions: CompilerOptionsConfig | undefined;
@@ -117,12 +117,22 @@ export interface PathInfo {
   /**
    * The absolute path.
    */
-  path: Path;
+  path: AbsolutePath;
+
+  /**
+   * The canonical form of the absolute path.
+   */
+  canonicalPath: CanonicalPath;
 
   /**
    * The corresponding absolute path in the input node if within root.
    */
-  pathInInput: Path | undefined;
+  pathInInput: AbsolutePath | undefined;
+
+  /**
+   * The canonical form of `pathInInput`.
+   */
+  canonicalPathInInput: CanonicalPath | undefined;
 
   /**
    * Path relative to root.
@@ -130,7 +140,30 @@ export interface PathInfo {
   relativePath: string | undefined;
 }
 
-export type Path = string & {
+/**
+ * An AbsolutePath is a path that has been normalized and provides the following
+ * guarantees:
+ *
+ * 1. The path is absolute.
+ * 2. Path separators have been normalized to slashes.
+ * 3. Any trailing slash has been removed.
+ *
+ * Generally speaking, AbsolutePaths should be preferred because they preserve
+ * casing, even on case-insensitive file systems. The exception is that
+ * CanonicalPaths should be used for things like cache keys, where the same file
+ * may be referred to by multiple casing permutations.
+ */
+export type AbsolutePath = string & {
+  __absolutePathBrand: any;
+};
+
+/**
+ * A CanonicalPath is an AbsolutePath that has been canonicalized. Primarily,
+ * this means that in addition to the guarantees of AbsolutePath, it has also
+ * had casing normalized on case-insensitive file systems. This is an alias of
+ * `ts.Path` type.
+ */
+export type CanonicalPath = string & {
   __pathBrand: any;
 };
 
@@ -157,7 +190,7 @@ export interface FileResolution extends Resolution {
 }
 
 export interface InputFileResolution extends FileResolution {
-  pathInInput: Path;
+  pathInInput: AbsolutePath;
   relativePath: string;
 
   isFile(): this is InputFileResolution;
@@ -172,7 +205,8 @@ export interface DirectoryResolution extends Resolution {
 }
 
 export interface InputDirectoryResolution extends DirectoryResolution {
-  pathInInput: Path;
+  pathInInput: AbsolutePath;
+  canonicalPathInInput: CanonicalPath;
   relativePath: string;
 
   isFile(): false;

--- a/lib/normalize-options.ts
+++ b/lib/normalize-options.ts
@@ -1,15 +1,15 @@
 import {
   isWithin,
   normalizePath,
-  toPath,
+  toAbsolutePath,
 } from "./fs/path-utils";
 import { CompilerOptionsConfig, NormalizedOptions, TypeScriptPluginOptions } from "./interfaces";
 
 export default function normalizeOptions(options: TypeScriptPluginOptions): NormalizedOptions {
-  const workingPath = toPath(options.workingPath === undefined ? process.cwd() : options.workingPath);
-  const rootPath = options.rootPath === undefined ? workingPath : toPath(options.rootPath, workingPath);
-  const projectPath = options.projectPath === undefined ? rootPath : toPath(options.projectPath, workingPath);
-  const buildPath = options.buildPath === undefined ? undefined : toPath(options.buildPath, workingPath);
+  const workingPath = toAbsolutePath(options.workingPath === undefined ? process.cwd() : options.workingPath);
+  const rootPath = options.rootPath === undefined ? workingPath : toAbsolutePath(options.rootPath, workingPath);
+  const projectPath = options.projectPath === undefined ? rootPath : toAbsolutePath(options.projectPath, workingPath);
+  const buildPath = options.buildPath === undefined ? undefined : toAbsolutePath(options.buildPath, workingPath);
   const tsconfig = options.tsconfig;
 
   if (buildPath !== undefined &&

--- a/lib/plugin.ts
+++ b/lib/plugin.ts
@@ -1,6 +1,6 @@
 import Compiler from "./compiler";
 import DiagnosticsHandler from "./diagnostics-handler";
-import { toPath } from "./fs/path-utils";
+import { toAbsolutePath } from "./fs/path-utils";
 import { BroccoliPlugin, heimdall } from "./helpers";
 import { NormalizedOptions, TypeScriptPluginOptions } from "./interfaces";
 import normalizeOptions from "./normalize-options";
@@ -52,8 +52,8 @@ export class TypeScriptPlugin extends BroccoliPlugin {
     let compiler = this.compiler;
     if (!compiler) {
       compiler = this.compiler = new Compiler(
-        toPath( this.inputPaths[0] ),
-        toPath( this.outputPath ),
+        toAbsolutePath( this.inputPaths[0] ),
+        toAbsolutePath( this.outputPath ),
         this.options,
         this.diagnosticHandler,
       );

--- a/tests/cases/basic-resolutions/lib/Components/CapitalizedComponent.ts
+++ b/tests/cases/basic-resolutions/lib/Components/CapitalizedComponent.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/tests/cases/basic-resolutions/lib/index.ts
+++ b/tests/cases/basic-resolutions/lib/index.ts
@@ -1,3 +1,4 @@
 export { default as A } from "./a";
 export { default as B } from "./b";
 export { default as C } from "./c";
+export { default as CapitalizedComponent } from "./Components/CapitalizedComponent";

--- a/tests/config-parser-test.ts
+++ b/tests/config-parser-test.ts
@@ -1,6 +1,6 @@
 import { createTempDir, TempDir } from "broccoli-test-helper";
 import * as ts from "typescript";
-import { ConfigParser, InputIO, PathResolver, toPath } from "../lib/index";
+import { ConfigParser, InputIO, PathResolver, toAbsolutePath, toCanonicalPath } from "../lib/index";
 
 let root: TempDir;
 let input: TempDir;
@@ -57,8 +57,8 @@ QUnit.module("config-parser", {
     },
   }, () => {
     QUnit.test("should be able to find the extended config", (assert) => {
-      const rootPath = toPath(root.path());
-      const inputPath = toPath(input.path());
+      const rootPath = toAbsolutePath(root.path());
+      const inputPath = toAbsolutePath(input.path());
       const parser = new ConfigParser(rootPath,
         undefined,
         "lib/tsconfig.json",
@@ -69,18 +69,18 @@ QUnit.module("config-parser", {
       const parsed = parser.parseConfig();
       assert.deepEqual( parsed.errors, [] );
       assert.deepEqual( parsed.options, {
-        "configFilePath": toPath("lib/tsconfig.json", rootPath),
+        "configFilePath": toAbsolutePath("lib/tsconfig.json", rootPath),
         "module": ts.ModuleKind.UMD,
         "moduleResolution": ts.ModuleResolutionKind.NodeJs,
-        "outDir": toPath("dist", rootPath),
+        "outDir": toCanonicalPath("dist", rootPath),
         "strictNullChecks": true,
         "typeRoots": [
-          toPath("typings", rootPath),
+          toCanonicalPath("typings", rootPath),
         ],
         "types": [ "foo" ],
       });
       assert.deepEqual( parsed.fileNames, [
-        toPath("lib/a.ts", rootPath),
+        toAbsolutePath("lib/a.ts", rootPath),
       ]);
     });
   });

--- a/tests/expectations/basic-resolutions/lib/Components/CapitalizedComponent.d.ts
+++ b/tests/expectations/basic-resolutions/lib/Components/CapitalizedComponent.d.ts
@@ -1,0 +1,2 @@
+declare const _default: {};
+export default _default;

--- a/tests/expectations/basic-resolutions/lib/Components/CapitalizedComponent.js
+++ b/tests/expectations/basic-resolutions/lib/Components/CapitalizedComponent.js
@@ -1,0 +1,4 @@
+"use strict";
+exports.__esModule = true;
+exports["default"] = {};
+//# sourceMappingURL=CapitalizedComponent.js.map

--- a/tests/expectations/basic-resolutions/lib/Components/CapitalizedComponent.js.map
+++ b/tests/expectations/basic-resolutions/lib/Components/CapitalizedComponent.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"CapitalizedComponent.js","sourceRoot":"","sources":["CapitalizedComponent.ts"],"names":[],"mappings":";;AAAA,qBAAe,EAAE,CAAC"}

--- a/tests/expectations/basic-resolutions/lib/index.d.ts
+++ b/tests/expectations/basic-resolutions/lib/index.d.ts
@@ -1,3 +1,4 @@
 export { default as A } from "./a";
 export { default as B } from "./b";
 export { default as C } from "./c";
+export { default as CapitalizedComponent } from "./Components/CapitalizedComponent";

--- a/tests/expectations/basic-resolutions/lib/index.js
+++ b/tests/expectations/basic-resolutions/lib/index.js
@@ -6,4 +6,6 @@ var b_1 = require("./b");
 exports.B = b_1["default"];
 var c_1 = require("./c");
 exports.C = c_1["default"];
+var CapitalizedComponent_1 = require("./Components/CapitalizedComponent");
+exports.CapitalizedComponent = CapitalizedComponent_1["default"];
 //# sourceMappingURL=index.js.map

--- a/tests/expectations/basic-resolutions/lib/index.js.map
+++ b/tests/expectations/basic-resolutions/lib/index.js.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"index.js","sourceRoot":"","sources":["index.ts"],"names":[],"mappings":";;AAAA,yBAAmC;AAA1B,gBAAA,SAAO,EAAK;AACrB,yBAAmC;AAA1B,gBAAA,SAAO,EAAK;AACrB,yBAAmC;AAA1B,gBAAA,SAAO,EAAK"}
+{"version":3,"file":"index.js","sourceRoot":"","sources":["index.ts"],"names":[],"mappings":";;AAAA,yBAAmC;AAA1B,gBAAA,SAAO,EAAK;AACrB,yBAAmC;AAA1B,gBAAA,SAAO,EAAK;AACrB,yBAAmC;AAA1B,gBAAA,SAAO,EAAK;AACrB,0EAAoF;AAA3E,sDAAA,SAAO,EAAwB"}

--- a/tests/path-utils-test.ts
+++ b/tests/path-utils-test.ts
@@ -1,9 +1,9 @@
-import { relativePathWithin, toPath } from "../lib/fs/path-utils";
+import { relativePathWithin, toAbsolutePath } from "../lib/fs/path-utils";
 
 QUnit.module("path-utils", () => {
   QUnit.test("relativePathWithin", (assert) => {
-    const a = toPath("a");
-    const b = toPath("a/b");
+    const a = toAbsolutePath("a");
+    const b = toAbsolutePath("a/b");
     assert.strictEqual(relativePathWithin(a, b), "b");
     assert.strictEqual(relativePathWithin(b, a), undefined);
   });

--- a/tests/typescript-project-cases-test.ts
+++ b/tests/typescript-project-cases-test.ts
@@ -1,7 +1,7 @@
 import { createBuilder, createTempDir } from "broccoli-test-helper";
 import ProjectRunner from "./typescript-project-runner";
 
-import { toPath, typescript } from "../lib/index";
+import { toAbsolutePath, typescript } from "../lib/index";
 
 // tslint:disable:no-console
 const runner = new ProjectRunner({
@@ -53,7 +53,7 @@ function removeRoots(errors: string | undefined, rootPath: string) {
   if (errors === undefined) {
     return;
   }
-  const root = toPath(rootPath);
+  const root = toAbsolutePath(rootPath);
   const pattern = new RegExp(escapeRegExp(root + "/"), "g");
   return errors.replace(pattern, "").toLowerCase();
 }


### PR DESCRIPTION
To support case-insensitive filesystems, TypeScript internally uses "canonicalized paths" to refer to files. Canonical paths are absolute paths with normalized path separators and, most importantly, transformed to be all lowercase on case-insensitive file systems. TypeScript uses the `Path` type to brand strings that are canonical paths to help enforce this rule in the type system.

Importantly, TypeScript only uses canonical paths internally for things like cache keys or file resolution. The original, non-canonicalized path is also stored and used when generating output. For example, given an input file called `COMPONENT.ts`, the TypeScript compiler will produce `COMPONENT.js`, even on case-insensitive file systems.

Currently, broccoli-typescript-compiler eagerly normalizes almost all paths internally into the canonicalized form. Primarily, this was desirable because canonicalizing has the benefit of normalizing paths into absolute paths, making working with files that may be in either the Broccoli input directory or the original working directory less ambiguous. However, it has the side effect of throwing out information about the original casing of files immediately as they enter the system.

In this commit, I introduce a new branded string type called `AbsolutePath`. To make it less ambiguous given this new type, I also rename the `Path` type to `CanonicalPath`. I update all places where we previously were coercing paths into `CanonicalPath`s to now coerce into `AbsolutePath`s. Effectively, we preserve all of the previous normalization except for lowercasing.

The exception is that we still normalize into `CanonicalPath`s in places where the path is used as a key of some sort. For example, we enforce canonical paths for cache keys, since a file may be referred to by different casing permutations in things like imports. This can occur when, e.g., a file called `SpongeBob.ts` is imported like this: `import SpongeBob from "sPoNgEbOb.ts"`.

The motivation for this change is that, without it, compiling a TypeScript project on a case-insensitive filesystem, like on OS X, can produce output that is broken on a case-sensitive filesystem.