### PR TITLE
Fix examples using "default" exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ npm install broccoli-typescript-compiler --save-dev
 ## How to use?
 
 ```js
-var typescript = require("broccoli-typescript-compiler").default;
+var typescript = require("broccoli-typescript-compiler").typescript;
 var cjsTree = typescript(inputTree, {
   tsconfig: {
     compilerOptions: {
@@ -62,7 +62,7 @@ let compiled = new TypescriptCompiler(input, options);
 This outputs only the emitted files from the compiled program.
 
 ```js
-const { default: typescript } = require("broccoli-typescript-compiler");
+const { typescript } = require("broccoli-typescript-compiler");
 
 let compiled = typescript(src, options);
 ```


### PR DESCRIPTION
The documentation for basic usage is incorrect in that it instructs you to use the `default` export, but there isn't a default export. Instead you should use `typescript` or `filterTypeScript` or `TypeScriptPlugin`, etc.