### PR TITLE
Add docs and script to check typescript upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,13 @@ This selects only ts files from the input to compile and merges emitted files wi
 const { filterTypescript } = require("broccoli-typescript-compiler");
 let output = filterTypescript(input, options);
 ```
+
+### Developemnt
+
+## How to upgrade `typescript`
+
+1. Update `typescript` in `package.json`
+2. Run `yarn run generate-tsconfig-interface`
+3. Update `vendor/typescript`. `cd vendor/typescript && git fetch --tags && git checkout v[new-version-of-typescript]`
+4. Commit all of the above changes
+5. Run `yarn test`. There may be some changes needed to the tests to accomidate changes in TypeScript.

--- a/tests/submodule-version-test.ts
+++ b/tests/submodule-version-test.ts
@@ -1,0 +1,8 @@
+QUnit.module("submodule typescript version", () => {
+  QUnit.test("matches installed typescript version", assert => {
+    const installedVersion = require('typescript/package').version;
+    const testFixturesVersion = require('../../vendor/typescript/package').version;
+    assert.equal(installedVersion, testFixturesVersion, `Installed Typescript version (${installedVersion}) does not match
+      the test fixture version in 'vendor/typescript' (${testFixturesVersion})`);
+  });
+});


### PR DESCRIPTION
Script makes sure version in yarn and version in `vendor/typescript` are the same.