### PR TITLE
Bump minor to 4.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ const { filterTypescript } = require("broccoli-typescript-compiler");
 let output = filterTypescript(input, options);
 ```
 
-### Developemnt
+## Development
 
-## How to upgrade `typescript`
+### How to upgrade `typescript`
 
 1. Update `typescript` in `package.json`
 2. Run `yarn run generate-tsconfig-interface`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "broccoli-typescript-compiler",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "A Broccoli plugin which compiles TypeScript files.",
   "keywords": [
     "TypeScript",


### PR DESCRIPTION
Releases upgraded typescript version to `3.1.6`. Also fixes README typos.