### PR TITLE
Add `shallow` to git submodule configuration.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "vendor/typescript"]
 	path = vendor/typescript
 	url = https://github.com/Microsoft/TypeScript.git
-	branch = release-2.9
+	shallow = true


### PR DESCRIPTION
From https://www.git-scm.com/docs/gitmodules#Documentation/gitmodules.txt-submoduleltnamegtshallow:

> When set to true, a clone of this submodule will be performed as a shallow clone (with a history depth of 1) unless the user explicitly asks for a non-shallow clone.